### PR TITLE
chore(asdf): AS-596 utilize asdf set and bump asdf action

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,89 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+Dockerfile
+.docker
+.dockerignore
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+**/.ropeproject
+
+# Vim swap files
+**/*.swp
+
+# VS Code
+.vscode/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @voxel51/aloha-shirts

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+# Rationale
+
+<!-- Explain why you are making this change. Describe the problem. -->
+
+## Changes
+
+<!-- Describe the changes. -->
+
+## Testing
+
+<!-- Describe the way the changes were tested. -->
+
+<!-- Optional Sections:
+
+## Screenshots
+## To Do
+## Notes
+## Related
+
+-->
+
+<!-- Template for collapsed sections
+<details>
+<summary></summary>
+</details>
+-->

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -62,13 +62,14 @@ jobs:
           DOCKER_REGISTRY: "${{ secrets.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/${{ secrets.GCP_DOCKER_REPOSITORY }}/"
           GCP_SM_KEY: "${{ secrets.GCP_SM_KEY }}"
           TAG: ${{ github.sha }}
-          GCP_COMPUTE_SERVER_NAME: "${{ secrets.GCP_COMPUTE_SERVER_NAME }}"
-          GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
+          GCP_COMPUTE_SERVER_NAME: ${{ secrets.GCP_COMPUTE_SERVER_NAME }}
+          GCP_COMPUTE_SERVER_ZONE: ${{ secrets.GCP_COMPUTE_SERVER_ZONE }} # Zone
+          GCP_LOCATION: ${{ secrets.GCP_LOCATION }} # Region
           GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
         run: |
           pushd ansible
           yq -i ".projects |= [\"$GCP_PROJECT\"]" ./inventory/gcp.yml
-          yq -i ".zones |= [\"$GCP_LOCATION\"]" ./inventory/gcp.yml
+          yq -i ".zones |= [\"$GCP_COMPUTE_SERVER_ZONE\"]" ./inventory/gcp.yml
           sudo pipx inject ansible-core -r requirements.txt
           ansible-playbook site.yml
           popd

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - 'voxelbot/**'
+      - 'ansible/**'
+      - 'dockerfile'
+      - 'docker-compose.yaml'
+      - '.github/workflows/build-and-publish.yml'
+
+concurrency:
+  group: "${{ github.ref_name }}-build-and-deploy"
 
 jobs:
   build:
@@ -11,40 +20,55 @@ jobs:
     permissions:
       contents: 'write'
       id-token: 'write'
-    env:
-      GCP_LOCATION: ''
-      GCP_PROJECT: ''
-      GCP_DOCKER_REPOSITORY: ''
-      GCP_HELM_REGISTRY: ''
-      GCP_SERVICE_ACCOUNT: ''
-      VERSION: ${{ github.sha }}
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          project_id: ${{ env.GCP_PROJECT }}
-          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+          project_id: ${{ secrets.GCP_PROJECT }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.ORG_GOOGLE_WORKLOAD_IDP }}
+
       - name: Set Up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
+        with:
+          install_components: 'beta'
+
       - name: Docker login
         run: |
           gcloud auth print-access-token | docker login \
             -u oauth2accesstoken \
-            --password-stdin "https://${{ env.GCP_LOCATION }}-docker.pkg.dev"
-      - name: Helm login
-        run: |
-          gcloud auth print-access-token | \
-            helm registry login -u oauth2accesstoken \
-            --password-stdin "https://${{ env.GCP_LOCATION }}-docker.pkg.dev"
+            --password-stdin "https://${{ secrets.GCP_LOCATION }}-docker.pkg.dev"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          file: ./external/VoxelBot/dockerfile
-          context: ./external/VoxelBot
-          tags: ${{ env.GCP_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT }}/${{ env.GCP_DOCKER_REPOSITORY }}/voxel51-discordbot:${{ env.VERSION }}
+          file: dockerfile
+          context: .
+          tags: ${{ secrets.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/${{ secrets.GCP_DOCKER_REPOSITORY }}/voxel51-discordbot:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,node=max
+
+      - name: Deploy via ansible
+        shell: bash
+        env:
+          DOCKER_REGISTRY: "${{ secrets.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/${{ secrets.GCP_DOCKER_REPOSITORY }}/"
+          GCP_SM_KEY: "${{ secrets.GCP_SM_KEY }}"
+          TAG: ${{ github.sha }}
+          GCP_COMPUTE_SERVER_NAME: "${{ secrets.GCP_COMPUTE_SERVER_NAME }}"
+          GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
+          GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
+        run: |
+          pushd ansible
+          yq -i ".projects |= [\"$GCP_PROJECT\"]" ./inventory/gcp.yml
+          yq -i ".zones |= [\"$GCP_LOCATION\"]" ./inventory/gcp.yml
+          sudo pipx inject ansible-core -r requirements.txt
+          ansible-playbook site.yml
+          popd

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,50 @@
+name: Docker Builds For Voxel51 Discord Bot
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'write'
+      id-token: 'write'
+    env:
+      GCP_LOCATION: ''
+      GCP_PROJECT: ''
+      GCP_DOCKER_REPOSITORY: ''
+      GCP_HELM_REGISTRY: ''
+      GCP_SERVICE_ACCOUNT: ''
+      VERSION: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.ORG_GOOGLE_WORKLOAD_IDP }}
+      - name: Set Up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Docker login
+        run: |
+          gcloud auth print-access-token | docker login \
+            -u oauth2accesstoken \
+            --password-stdin "https://${{ env.GCP_LOCATION }}-docker.pkg.dev"
+      - name: Helm login
+        run: |
+          gcloud auth print-access-token | \
+            helm registry login -u oauth2accesstoken \
+            --password-stdin "https://${{ env.GCP_LOCATION }}-docker.pkg.dev"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          file: ./external/VoxelBot/dockerfile
+          context: ./external/VoxelBot
+          tags: ${{ env.GCP_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT }}/${{ env.GCP_DOCKER_REPOSITORY }}/voxel51-discordbot:${{ env.VERSION }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,18 @@
+---
+name: pre-commit
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - uses: actions/setup-python@v5.2.0
+      - name: install asdf & tools
+        uses: asdf-vm/actions/install@v3.0.2
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@v4.1.6
       - uses: actions/setup-python@v5.2.0
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@v3.0.2
+        uses: asdf-vm/actions/install@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
       - uses: pre-commit/action@v3.0.1

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+---
+default: true
+
+MD013:  # Line Length
+  code_blocks: false
+  tables: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,53 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-added-large-files
+        exclude: argocd/crds/7.3.6/applicationset-crd.yaml
+      - id: check-case-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: check-yaml
+        args:
+          - --allow-multiple-document
+        exclude: apps/platform/atlantis/templates/.*yaml|argocd/crds/.*yaml
+      - id: detect-aws-credentials
+        args:
+          - --allow-missing-credentials
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: pretty-format-json
+      - id: trailing-whitespace
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.4
+    hooks:
+      - id: forbid-tabs
+        exclude_types:
+          - makefile
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.36.0
+    hooks:
+      - id: markdownlint
+      - id: markdownlint-fix
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.32.0
+    hooks:
+      - id: yamllint
+        entry: yamllint --config-file .yamllint.yaml
+        exclude: apps/platform/atlantis/templates/.*yaml|argocd/crds/.*yaml
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args:
+          - --exclude-secrets
+          - '(auth|secretName|secretKey)'
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.0
+    hooks:
+      - id: actionlint
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,5 @@
+helm 3.15.1
+kubectl 1.30.1
+pre-commit 3.4.0
+python 3.10.14
+shellcheck 0.10.0

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,6 @@
+---
+extends: default
+rules:
+  indentation:
+    spaces: 2
+  line-length: disable

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+# Help
+.PHONY: $(shell sed -n -e '/^$$/ { n ; /^[^ .\#][^ ]*:/ { s/:.*$$// ; p ; } ; }' $(MAKEFILE_LIST))
+
+help:
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.DEFAULT_GOAL := help
+
+asdf:  ## Update plugins, add plugins, install plugins, set local, reshim
+	@echo "Updating asdf plugins..."
+	@asdf plugin update --all >/dev/null 2>&1 || true
+
+	@echo "Adding asdf plugins..."
+	@cut -d" " -f1 .tool-versions | xargs -I{} asdf plugin add {} >/dev/null 2>&1 || true
+
+	@echo "Installing asdf tools..."
+	@cat .tool-versions | xargs -I{} bash -c 'asdf install {}'
+
+	@echo "Setting local package versions..."
+	@cat .tool-versions | xargs -I{} bash -c 'asdf local {}'
+
+	@echo "Reshimming.."
+	@asdf reshim
+
+hooks:  ## Install git hooks (pre-commit)
+	@pre-commit install
+	@pre-commit install --hook-type commit-msg
+
+	# Install environments for all available hooks now (rather than when they are first executed)
+	@pre-commit install --install-hooks
+
+pre-commit:  ## Run pre-commit against all files
+	@pre-commit run -a

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ asdf:  ## Update plugins, add plugins, install plugins, set local, reshim
 	@cat .tool-versions | xargs -I{} bash -c 'asdf install {}'
 
 	@echo "Setting local package versions..."
-	@cat .tool-versions | xargs -I{} bash -c 'asdf local {}'
+	@cat .tool-versions | xargs -I{} bash -c 'asdf set {}'
 
 	@echo "Reshimming.."
 	@asdf reshim

--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
 # Voxelbot
 
-Voxelbot is a versatile Discord bot designed for the FiftyOne Discord community, utilizing the [Hata](https://github.com/HuyaneMatsu/hata) framework. It offers a range of features for server management, user interaction, and community engagement.
+Voxelbot is a versatile Discord bot designed for the FiftyOne Discord
+community, utilizing the
+[Hata](https://github.com/HuyaneMatsu/hata)
+framework. It offers a range of features for server management, user interaction,
+and community engagement.
 
 ## Features
 
-Voxelbot’s functionality is modular, with each feature residing in its own plugin located under `voxelbot/plugins`. Below is an overview of the core plugins:
+Voxelbot’s functionality is modular, with each feature residing in its own
+plugin located under `voxelbot/plugins`. Below is an overview of the core plugins:
 
-- **code_metrics.py**: Tracks and provides metrics related to the fiftyone repo. Useful for monitoring development activity within the Discord server.
-- **faqs.py**: Manages a frequently asked questions (FAQ) system, allowing server members to easily find answers to common questions.
-- **moderation_menu.py**: ability to softkick someone Bans a user, then unbans them, deleting their messages in the process.
-- **easy_github_contribution.py**: Simplifies the verification of contributors to open-source projects.
+- **code_metrics.py**: Tracks and provides metrics related to the fiftyone repo.
+    Useful for monitoring development activity within the Discord server.
+- **faqs.py**: Manages a frequently asked questions (FAQ) system,
+    allowing server members to easily find answers to common questions.
+- **moderation_menu.py**: ability to softkick someone Bans a user,
+    then unbans them, deleting their messages in the process.
+- **easy_github_contribution.py**: Simplifies the verification of
+    contributors to open-source projects.
 - **logging.py**: Logs the activity on the discord to monitor any bad behaviour
 - **misc.py**: Some easy simple commands
 
@@ -20,11 +29,16 @@ git clone https://github.com/yourusername/voxelbot.git
 cd voxelbot
 ```
 
-Configure the bot: Set up your required vriables in the `.env` file inside voxelbot or export them in your shell.
+Configure the bot: Set up your required vriables in the `.env` file inside
+voxelbot or export them in your shell.
 
 ### Running in docker
 
-The simplest and most efficient way to run Voxelbot is through Docker. We've provided a `docker-run.sh` script that sets up and runs the bot inside a Docker container. This ensures that the bot runs in a consistent environment without needing to manually manage dependencies.
+The simplest and most efficient way to run Voxelbot is through Docker.
+We've provided a `docker-run.sh` script that sets up and runs the bot
+inside a Docker container.
+This ensures that the bot runs in a consistent environment without
+needing to manually manage dependencies.
 
 To run the bot using Docker:
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,43 @@
+# Ansible Automation For Docker Compose Systems
+
+In order to provide a GitOps
+flow for docker compose, we wrote a suite of ansible tooling
+to be triggered via GitHub actions.
+
+This automation includes a few task sets:
+
+1. A task set to log in to GCP and internal docker registries
+1. A task set to deploy our docker compose stacks. This includes:
+      1. Ensuring there is a `.env` file either in google secrets manager
+         or on disk for the stack to use.
+      1. Ensuring the ansible user is part of the `docker` linux group.
+      1. Bringing up the docker compose stack
+
+## Variables
+
+Host variables are documented and defaulted in [this](group_vars/all.yaml) file.
+
+## Running
+
+You can run locally via the `ansible-playbook` command.
+You can set your hosts via the command line via the `GCP_COMPUTE_SERVER_NAME`
+environment variable.
+
+A list of environment variables:
+
+* `DOCKER_REGISTRY` - The registry to pull images from
+* `GCP_COMPUTE_SERVER_NAME` - The ansbile host or group to deploy to
+* `GCP_LOCATION` - The GCP location of the registry
+* `GCP_SM_KEY` - The GCP secret with .env file contents
+* `TAG` - The image tag to deploy
+
+An example:
+
+```shell
+export DOCKER_REGISTRY="us.gcr.io/.../..."
+export GCP_COMPUTE_SERVER_NAME=some-server-name
+export GCP_LOCATION=some-gcp-location
+export GCP_SM_KEY="some-key-name"
+export TAG="abc123"
+ansible-playbook main.yml
+```

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,16 @@
+[inventory]
+enable_plugins = gcp_compute
+
+[defaults]
+inventory = inventory/gcp.yml
+
+[ssh_connection]
+# Enabling pipelining reduces the number of SSH operations required
+# to execute a module on the remote server.
+# This can result in a significant performance improvement
+# when enabled.
+pipelining = True
+ssh_executable = scripts/gcp-ssh-wrapper.sh
+ssh_args = None
+scp_if_ssh = True
+scp_executable = scripts/gcp-scp-wrapper.sh

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -1,0 +1,8 @@
+---
+ansible_ssh_args: --tunnel-through-iap --zone={{ zone }} --project={{ project }} --no-user-output-enabled --quiet
+ansible_scp_extra_args: --tunnel-through-iap --zone={{ zone }} --quiet
+docker_dir: /deploy/voxel51-discordbot
+compose_async_timeout: 30
+gcp_sm_key: "{{ lookup('env', 'GCP_SM_KEY') }}"
+docker_registry: "{{ lookup('env', 'DOCKER_REGISTRY') }}"
+tag: "{{ lookup('env', 'TAG') }}"

--- a/ansible/inventory/gcp.yml
+++ b/ansible/inventory/gcp.yml
@@ -1,0 +1,8 @@
+plugin: google.cloud.gcp_compute
+projects: []
+zones: []
+filters:
+  - status = RUNNING
+auth_kind: application
+hostnames:
+  - name

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,0 +1,2 @@
+google-auth==2.35.0
+requests==2.31.0

--- a/ansible/scripts/gcp-scp-wrapper.sh
+++ b/ansible/scripts/gcp-scp-wrapper.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# This is a wrapper script allowing to use GCP's IAP option to connect
+# to our servers.
+
+# Ansible passes a large number of SSH parameters along with the hostname as the
+# second to last argument and the command as the last. We will pop the last two
+# arguments off of the list and then pass all of the other SSH flags through
+# without modification:
+host="${@: -2: 1}"
+cmd="${@: -1: 1}"
+
+# Unfortunately ansible has hardcoded scp options, so we need to filter these out
+# It's an ugly hack, but for now we'll only accept the options starting with '--'
+declare -a opts
+for scp_arg in "${@: 1: $# -3}" ; do
+        if [[ "${scp_arg}" == --* ]] ; then
+                opts+="${scp_arg} "
+        fi
+done
+
+# Remove [] around our host, as gcloud scp doesn't understand this syntax
+cmd=`echo "${cmd}" | tr -d []`
+
+exec gcloud beta compute scp $opts "${host}" "${cmd}"

--- a/ansible/scripts/gcp-ssh-wrapper.sh
+++ b/ansible/scripts/gcp-ssh-wrapper.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# This is a wrapper script allowing to use GCP's IAP SSH option to connect
+# to our servers.
+
+# Ansible passes a large number of SSH parameters along with the hostname as the
+# second to last argument and the command as the last. We will pop the last two
+# arguments off of the list and then pass all of the other SSH flags through
+# without modification:
+host="${@: -2: 1}"
+cmd="${@: -1: 1}"
+
+# Unfortunately ansible has hardcoded ssh options, so we need to filter these out
+# It's an ugly hack, but for now we'll only accept the options starting with '--'
+declare -a opts
+for ssh_arg in "${@: 1: $# -3}" ; do
+        if [[ "${ssh_arg}" == --* ]] ; then
+                opts+="${ssh_arg} "
+        fi
+done
+
+exec gcloud beta compute ssh $opts "${host}" -- -C "${cmd}"

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,0 +1,14 @@
+---
+- name: Deploy Voxel51 Discord Bot
+  hosts: "{{ lookup('env', 'GCP_COMPUTE_SERVER_NAME') }}"
+  gather_facts: true
+
+  tasks:
+    - name: Sync User Permissions
+      include_tasks: tasks/users.yml
+
+    - name: Ensure paths and dot envs
+      include_tasks: tasks/fs.yml
+
+    - name: Deploy stack
+      include_tasks: tasks/docker.yml

--- a/ansible/tasks/docker.yml
+++ b/ansible/tasks/docker.yml
@@ -1,0 +1,33 @@
+---
+- name: Docker login
+  shell: |
+    gcloud auth configure-docker \
+      "{{ lookup('env', 'GCP_LOCATION') }}-docker.pkg.dev" \
+      --quiet
+
+- name: Pull docker images
+  community.docker.docker_compose_v2_pull:
+    project_src: "{{ docker_dir }}"
+  environment:
+    DOCKER_REGISTRY: "{{ docker_registry }}"
+    TAG: "{{ tag }}"
+
+- name: Create and start services
+  community.docker.docker_compose_v2:
+    project_src: "{{ docker_dir }}"
+    build: "never"
+  environment:
+    DOCKER_REGISTRY: "{{ docker_registry }}"
+    TAG: "{{ tag }}"
+  register: compose_out
+
+# Assert that states == running here
+- name: Verify all services are running
+  ansible.builtin.assert:
+    that:
+      - item.State == 'running'
+    msg: "{{ item.Name }} failed to start properly"
+    quiet: true
+  with_items: "{{ compose_out.containers }}"
+  loop_control:
+    label: "{{ item.Name }}"

--- a/ansible/tasks/fs.yml
+++ b/ansible/tasks/fs.yml
@@ -1,0 +1,38 @@
+---
+
+- name: Create directories
+  become: true
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0770'
+    owner: "{{ ansible_user_id }}"
+    group: fiftyone
+    recurse: true
+  loop:
+    - /deploy
+    - "{{ docker_dir }}"
+
+- name: Read from gcp
+  ansible.builtin.shell: |
+    gcloud secrets versions access latest \
+      --secret="{{ gcp_sm_key }}" \
+      --project="{{ project }}"
+  register: _env
+
+- name: Save to .env file
+  ansible.builtin.copy:
+    content: "{{ _env.stdout }}"
+    dest: "{{ docker_dir }}/.env"
+    owner: "{{ ansible_user_id }}"
+    group: fiftyone
+    mode: '0660'
+  no_log: true
+
+- name: Move compose file over
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../docker-compose.yaml"
+    dest: "{{ docker_dir }}/docker-compose.yaml"
+    group: fiftyone
+    mode: '0660'
+  no_log: true

--- a/ansible/tasks/users.yml
+++ b/ansible/tasks/users.yml
@@ -1,0 +1,19 @@
+---
+- name: Add groups to the system
+  become: true
+  ansible.builtin.group:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - docker
+    - fiftyone
+
+- name: Add user to group
+  become: true
+  ansible.builtin.user:
+    name: "{{ ansible_user_id }}"
+    groups: "{{ item }}"
+    append: true
+  loop:
+    - docker
+    - fiftyone

--- a/assets/faqs/fiftyone-teams.md
+++ b/assets/faqs/fiftyone-teams.md
@@ -1,7 +1,14 @@
 # Fiftyone Teams
 
-[FiftyOne Teams](https://voxel51.com/fiftyone-teams/) enables multiple users to securely collaborate on the same datasets and models, either on-premises or in the cloud, all built on top of the open source FiftyOne workflows that you’re already relying on.
+[FiftyOne Teams](https://voxel51.com/fiftyone-teams/)
+enables multiple users to securely collaborate on the same
+datasets and models, either on-premises or in the cloud,
+all built on top of the open source FiftyOne workflows that
+you’re already relying on.
 
-You can try it out [here](https://try.fiftyone.ai/)
+You can try it out
+[here](https://try.fiftyone.ai/)
 
-If you like what you see [lets have a call](https://voxel51.com/schedule-teams-workshop) to help you get setup
+If you like what you see
+[lets have a call](https://voxel51.com/schedule-teams-workshop)
+to help you get setup

--- a/assets/faqs/quickstart.md
+++ b/assets/faqs/quickstart.md
@@ -1,1 +1,5 @@
-Welcome to fiftyone! You can start by reading through the documentation here: <https://docs.voxel51.com/index.html>
+# Quickstart
+
+Welcome to fiftyone!
+You can start by reading through the documentation
+here[https://docs.voxel51.com/index.html]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+---
+
+services:
+  discordbot:
+    image: "${DOCKER_REGISTRY:-}voxel51-discordbot:${TAG:-latest}"
+    build:
+      context: .
+      dockerfile: dockerfile
+    env_file:
+      - .env
+    restart: unless-stopped
+    volumes:
+      - discordbot:/app/persist/:rw
+
+volumes:
+  discordbot: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ dependencies = [
     "hata[all]",
     "pygithub",
     "aiosqlite",
-    "inotify-simple",
     "pygal",
     "cairosvg",
     "cryptography",

--- a/voxelbot/plugins/easy_github_contribution.py
+++ b/voxelbot/plugins/easy_github_contribution.py
@@ -17,6 +17,7 @@ ACCEPT_BUTTON = Button("Accept", emoji=ACCEPT_EMOJI, custom_id="egc.accept", sty
 DENY_BUTTON = Button("Deny", emoji=DENY_EMOJI, custom_id="egc.deny", style=ButtonStyle.red)
 COMPONENTS = Row(ACCEPT_BUTTON, DENY_BUTTON)
 
+VOXEL51_REPOS = [r.name for r in GITHUB.get_repos(type="public")]
 
 @ALL.events  # type: ignore
 async def message_create(client: Client, message: Message):
@@ -131,3 +132,46 @@ async def egc_deny(client: Client, event: InteractionEvent):
     await client.message_delete(event.message.referenced_message)
     await client.interaction_component_acknowledge(event)
     await client.interaction_response_message_delete(event)
+
+
+@ALL.interactions(is_global=True, wait_for_acknowledgement=True)
+async def search_issues(client: Client, query: ("str", "Topic to search")):  # type: ignore
+    """Allow users to search for relevant GitHub issues and return the top-5 results."""
+    if not query:
+        return await client.message_create(message.channel, "Please provide a search query.")
+
+    try:
+        repo = GITHUB.get_repo("voxel51/fiftyone")
+        issues = repo.search_issues(f'{query} in:title,body')
+        if issues.totalCount == 0:
+            return await client.message_create(message.channel, "No relevant issues found.")
+
+        issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
+        await client.message_create(message.channel, f"Top relevant issues:\n{issue_links}")
+
+
+@ALL.interactions(is_global=True, wait_for_acknowledgement=True)
+async def ref_issue(query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
+    """Provides specific metric(s) for the voxel51/fiftyone repository."""
+    if repo not in (VOXEL51_REPOS):
+        abort("Must be Voxel51 repo.")
+    GITHUB.get_repo(repo)
+    issues = repo.search_issues(f'{query} in:title,body')
+    
+    if issues.totalCount == 0:
+            return await client.message_create(message.channel, "No relevant issues found.")
+    
+    issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
+    await client.message_create(message.channel, f"Top relevant issues:\n{issue_links}")
+    
+    except GithubException as e:
+        logging.error(f"GitHub API error: {e}")
+        await client.message_create(message.channel, "An error occurred while searching for issues. Please try again later.")
+
+
+@repo_metrics.autocomplete("repo")
+async def repo_autocomplete(value):
+    if not value:
+        return VOXEL51_REPOS
+    value_lower = value.lower()
+    return [repo for repo in VOXEL51_REPOS if repo.startswith(value_lower)]

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -21,14 +21,15 @@ async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("st
     elif repo is None:
         repo = "voxel51/fiftyone"  # default
     
-    GITHUB.get_repo(repo)
-    issues = repo.search_issues(f'{query} in:title,body')
-    
-    if issues.totalCount == 0:
+    try:
+        GITHUB.get_repo(repo)
+        issues = repo.search_issues(f'{query} in:title,body')
+        
+        if issues.totalCount == 0:
             return await client.message_create(message.channel, "No relevant issues found.")
-    
-    issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
-    await client.message_create(event.channel, f"Top relevant issues:\n{issue_links}")
+        
+        issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
+        await client.message_create(event.channel, f"Top relevant issues:\n{issue_links}")
     
     except GithubException as e:
         logging.error(f"GitHub API error: {e}")

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -22,8 +22,8 @@ async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("st
         repo = "voxel51/fiftyone"  # default
     
     try:
-        GITHUB.get_repo(repo)
-        issues = repo.search_issues(f'{query} in:title,body')
+        repo = GITHUB.get_repo(repo)
+        issues = GITHUB.search_issues(f"{query} repo:{repo.full_name} in:title,body")
         
         if issues.totalCount == 0:
             return await client.message_create(event.channel, "No relevant issues found.")

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -10,7 +10,7 @@ ALL = ClientWrapper()
 
 GITHUB = Github(auth=Auth.Token(GITHUB_TOKEN))
 ORG = GITHUB.get_organization("voxel51")
-VOXEL51_REPOS = [r.name for r in ORG.get_repos(type="public")]
+VOXEL51_REPOS = [r.full_name for r in ORG.get_repos(type="public")]
 
 
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -1,7 +1,10 @@
 import logging
 
 from github import Auth, Github, GithubException
-from hata import Client, ClientWrapper
+from github.Issue import Issue
+from github.Organization import Organization
+from github.PaginatedList import PaginatedList
+from hata import Client, ClientWrapper, InteractionEvent
 from hata.ext.slash import abort
 
 from ..constants import GITHUB_TOKEN
@@ -9,8 +12,8 @@ from ..constants import GITHUB_TOKEN
 ALL = ClientWrapper()
 
 GITHUB = Github(auth=Auth.Token(GITHUB_TOKEN))
-ORG = GITHUB.get_organization("voxel51")
-VOXEL51_REPOS = [r.full_name for r in ORG.get_repos(type="public")]
+ORG: Organization = GITHUB.get_organization("voxel51")
+VOXEL51_REPOS: list[str] = [r.full_name for r in ORG.get_repos(type="public")]
 
 
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
@@ -21,7 +24,7 @@ async def ref_issue(
     repo: ("str", "Repo to search."),  # type: ignore # noqa: F722
 ):
     """
-    Returns a list of top-five related issues from a specified Voxel51 repository based on the 
+    Returns a list of top-five related issues from a specified Voxel51 repository based on the
     user's query.
 
     Args:
@@ -35,26 +38,41 @@ async def ref_issue(
     """
     if repo not in VOXEL51_REPOS:
         abort("Must be Voxel51 repo.")
-    elif repo is None:
-        repo = "voxel51/fiftyone"  # default
-    
+
     try:
-        issues = GITHUB.search_issues(f"{query} repo:{repo} in:title,body is:issue")
-        
+        issues: PaginatedList[Issue] = GITHUB.search_issues(
+            f"{query} repo:{repo} in:title,body is:issue"
+        )
+
         if issues.totalCount == 0:
             return await client.message_create(event.channel, "No relevant issues found.")
-        
-        issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
+
+        issue_links: str = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
         await client.message_create(event.channel, f"Top relevant issues:\n{issue_links}")
-    
+
     except GithubException as e:
         logging.error(f"GitHub API error: {e}")
-        await client.message_create(event.channel, "An error occurred while searching for issues. Please try again later.")
+        await client.message_create(
+            event.channel, "An error occurred while searching for issues. Please try again later."
+        )
 
 
 @ref_issue.autocomplete("repo")
-async def repo_autocomplete(value):
+async def repo_autocomplete(value) -> list[str]:
+    """
+    Provides autocomplete suggestions for repository names.
+
+    This function is triggered by the `ref_issue.autocomplete` decorator with the
+    argument "repo". It returns a list of repository names that match the given
+    input value. If no value is provided, it returns the full list of repositories.
+
+    Args:
+        value (str): The input value to match against repository names.
+
+    Returns:
+        list[str]: A list of repository names that start with the input value.
+    """
     if not value:
         return VOXEL51_REPOS
-    value_lower = value.lower()
+    value_lower: str = value.lower()
     return [repo for repo in VOXEL51_REPOS if repo.startswith(value_lower)]

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -15,8 +15,10 @@ VOXEL51_REPOS = [r.name for r in GITHUB.get_repos(type="public")]
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
 async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
     """Provides specific metric(s) for the voxel51/fiftyone repository."""
-    if repo not in (VOXEL51_REPOS):
+    if repo is not None and not in (VOXEL51_REPOS):
         abort("Must be Voxel51 repo.")
+    elif repo is None:
+        repo = "voxel51/fiftyone"  # default
     
     GITHUB.get_repo(repo)
     issues = repo.search_issues(f'{query} in:title,body')

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -15,7 +15,7 @@ VOXEL51_REPOS = [r.name for r in GITHUB.get_repos(type="public")]
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
 async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
     """Provides specific metric(s) for the voxel51/fiftyone repository."""
-    if repo is not None and not in (VOXEL51_REPOS):
+    if repo is not None and repo not in (VOXEL51_REPOS):
         abort("Must be Voxel51 repo.")
     elif repo is None:
         repo = "voxel51/fiftyone"  # default

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -14,9 +14,26 @@ VOXEL51_REPOS = [r.full_name for r in ORG.get_repos(type="public")]
 
 
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
-async ref_issue(client: Client, event: InteractionEvent, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
-    """Returns list of top-five related issues from Voxel51 repository based on user query."""
-    if repo is not None and repo not in VOXEL51_REPOS:
+async def ref_issue(
+    client: Client,
+    event: InteractionEvent,
+    query: ("str", "Topic to search"),  # type: ignore # noqa: F722
+    repo: ("str", "Repo to search."),  # type: ignore # noqa: F722
+):
+    """
+    Returns a list of top-five related issues from a specified Voxel51 repository based on the 
+    user's query.
+
+    Args:
+        client (Client): The client instance to use for sending messages.
+        event (InteractionEvent): The interaction event that triggered this function.
+        query (str): The topic to search for in the issues.
+        repo (str): The repository to search within.
+
+    Raises:
+        GithubException: If there is an error with the GitHub API request.
+    """
+    if repo not in VOXEL51_REPOS:
         abort("Must be Voxel51 repo.")
     elif repo is None:
         repo = "voxel51/fiftyone"  # default

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -26,7 +26,7 @@ async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("st
         issues = repo.search_issues(f'{query} in:title,body')
         
         if issues.totalCount == 0:
-            return await client.message_create(message.channel, "No relevant issues found.")
+            return await client.message_create(event.channel, "No relevant issues found.")
         
         issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
         await client.message_create(event.channel, f"Top relevant issues:\n{issue_links}")

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -1,6 +1,6 @@
 import logging
 
-from github import Auth, Github
+from github import Auth, Github, GithubException
 from hata import Client, ClientWrapper
 from hata.ext.slash import abort
 
@@ -15,7 +15,7 @@ VOXEL51_REPOS = [r.name for r in GITHUB.get_repos(type="public")]
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
 async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
     """Provides specific metric(s) for the voxel51/fiftyone repository."""
-    if repo is not None and repo not in (VOXEL51_REPOS):
+    if repo is not None and repo not in VOXEL51_REPOS:
         abort("Must be Voxel51 repo.")
     elif repo is None:
         repo = "voxel51/fiftyone"  # default
@@ -34,7 +34,7 @@ async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("st
         await client.message_create(event.channel, "An error occurred while searching for issues. Please try again later.")
 
 
-@repo_metrics.autocomplete("repo")
+@ref_issue.autocomplete("repo")
 async def repo_autocomplete(value):
     if not value:
         return VOXEL51_REPOS

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -1,0 +1,40 @@
+import logging
+
+from github import Auth, Github
+from hata import Client, ClientWrapper
+from hata.ext.slash import abort
+
+from ..constants import GITHUB_TOKEN
+
+ALL = ClientWrapper()
+
+GITHUB = Github(auth=Auth.Token(GITHUB_TOKEN))
+VOXEL51_REPOS = [r.name for r in GITHUB.get_repos(type="public")]
+
+
+@ALL.interactions(is_global=True, wait_for_acknowledgement=True)
+async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
+    """Provides specific metric(s) for the voxel51/fiftyone repository."""
+    if repo not in (VOXEL51_REPOS):
+        abort("Must be Voxel51 repo.")
+    
+    GITHUB.get_repo(repo)
+    issues = repo.search_issues(f'{query} in:title,body')
+    
+    if issues.totalCount == 0:
+            return await client.message_create(message.channel, "No relevant issues found.")
+    
+    issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
+    await client.message_create(event.channel, f"Top relevant issues:\n{issue_links}")
+    
+    except GithubException as e:
+        logging.error(f"GitHub API error: {e}")
+        await client.message_create(event.channel, "An error occurred while searching for issues. Please try again later.")
+
+
+@repo_metrics.autocomplete("repo")
+async def repo_autocomplete(value):
+    if not value:
+        return VOXEL51_REPOS
+    value_lower = value.lower()
+    return [repo for repo in VOXEL51_REPOS if repo.startswith(value_lower)]

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -23,7 +23,7 @@ async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("st
     
     try:
         repo = GITHUB.get_repo(repo)
-        issues = GITHUB.search_issues(f"{query} repo:{repo.full_name} in:title,body")
+        issues = GITHUB.search_issues(f"{query} repo:{repo.full_name} in:title,body is:issue")
         
         if issues.totalCount == 0:
             return await client.message_create(event.channel, "No relevant issues found.")

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -15,7 +15,7 @@ VOXEL51_REPOS = [r.full_name for r in ORG.get_repos(type="public")]
 
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
 async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
-    """Provides specific metric(s) for the voxel51/fiftyone repository."""
+    """Returns list of top-five related issues from Voxel51 repository based on user query."""
     if repo is not None and repo not in VOXEL51_REPOS:
         abort("Must be Voxel51 repo.")
     elif repo is None:

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -14,7 +14,7 @@ VOXEL51_REPOS = [r.full_name for r in ORG.get_repos(type="public")]
 
 
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
-async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
+async ref_issue(client: Client, event: InteractionEvent, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
     """Returns list of top-five related issues from Voxel51 repository based on user query."""
     if repo is not None and repo not in VOXEL51_REPOS:
         abort("Must be Voxel51 repo.")

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -9,7 +9,8 @@ from ..constants import GITHUB_TOKEN
 ALL = ClientWrapper()
 
 GITHUB = Github(auth=Auth.Token(GITHUB_TOKEN))
-VOXEL51_REPOS = [r.name for r in GITHUB.get_repos(type="public")]
+ORG = GITHUB.get_organization("voxel51")
+VOXEL51_REPOS = [r.name for r in ORG.get_repos(type="public")]
 
 
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -24,8 +24,7 @@ async def ref_issue(
     repo: ("str", "Repo to search."),  # type: ignore # noqa: F722
 ):
     """
-    Returns a list of top-five related issues from a specified Voxel51 repository based on the
-    user's query.
+    Returns top-five related issues from a Voxel51 repository based on the user's query.
 
     Args:
         client (Client): The client instance to use for sending messages.

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -22,8 +22,7 @@ async ref_issue(client: Client, event: InteractionEvent, query: ("str", "Topic t
         repo = "voxel51/fiftyone"  # default
     
     try:
-        repo = GITHUB.get_repo(repo)
-        issues = GITHUB.search_issues(f"{query} repo:{repo.full_name} in:title,body is:issue")
+        issues = GITHUB.search_issues(f"{query} repo:{repo} in:title,body is:issue")
         
         if issues.totalCount == 0:
             return await client.message_create(event.channel, "No relevant issues found.")


### PR DESCRIPTION
# Rationale

`asdf local` is deprecated and removed in newer versions. We can switch to `asdf set`. We can also bump to the newer action to avoid that deprecation notice which munges STDOUT.

## Changes

* Bump ASDF action to use the latest SHA
* Migrate from `asdf local` to `asdf set`

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
